### PR TITLE
fix: open external Learn More links in a new tab

### DIFF
--- a/client/src/components/ResourceCard.jsx
+++ b/client/src/components/ResourceCard.jsx
@@ -76,9 +76,13 @@ export default function ResourceCard({
 
   if (link) {
     return (
-      <Link to={link} className="block">
-        {cardContent}
-      </Link>
+      // <Link to={link} className="block">
+      //   {cardContent}
+      // </Link>
+      <a href={link} target="_blank" rel="noopener noreferrer" className="block">
+         {cardContent}
+      </a>
+
     )
   }
 


### PR DESCRIPTION
This PR ensures that external resource links (Learn More  button) open in a new browser tab, preserving the user’s session on the current site.

 Changes Made:
- Replaced Link with anchor tag.
- Ensured proper accessibility and security with rel="noopener noreferrer".

✅ Benefits:
- Prevents unexpected navigation away from the site
- Improves UX by keeping users’ context
- Aligns with standard external link behavior

Attached Video:-

https://github.com/user-attachments/assets/6c9d1983-f2c1-467b-bb39-add61a4a144c

