### PR TITLE
issue create automate message added

### DIFF
--- a/.github/workflows/issue-create-automate-message.yml
+++ b/.github/workflows/issue-create-automate-message.yml
@@ -1,0 +1,28 @@
+name: Auto Comment on Issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Comment to Issue
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issueNumber = context.issue.number;
+            const commentBody = `### Thank you for raising this issue!\n We'll review it as soon as possible. We truly appreciate your contributions! ✨\n\n> Meanwhile make sure you've visited the README.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md before creating a PR for this. Also, please do NOT create a PR until this issue has been assigned to you. 😊`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: commentBody
+            });
+
+            console.log('Comment added successfully.');


### PR DESCRIPTION
I have added the issue create automate message github actions bot. Please @pushh-k check and merge the PR and add the gssoc25 label along with the level of contribution. Let me know if require any changes.
fixes #88 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically posts a welcome comment on newly opened issues with links to README, CONTRIBUTING, and Code of Conduct.
  * Clarifies contribution flow by asking contributors not to open a PR until the issue is assigned.

* **Chores**
  * Introduces an issue triage automation to streamline guidance for new issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->